### PR TITLE
Fix background image URL syntax in speaker card in /layouts/sessions/single.html

### DIFF
--- a/layouts/sessions/single.html
+++ b/layouts/sessions/single.html
@@ -21,7 +21,7 @@
 				<li>
 					<a class="visually-hidden" aria-hidden="true" href="/speakers/{{ .Params.key }}">{{ .Params.name }}</a>
 					<a class="speaker" href="/speakers/{{ .Params.key }}">
-						<div class="speaker-img" style="background-image: url({{ .Params.photoURL }});"></div>
+						<div class="speaker-img" style="background-image: url('{{ .Params.photoURL }}');"></div>
 						<strong class="speaker-name">{{ .Params.name }}</strong>
 						<span class="speaker-country">{{ .Params.city }}</span>
 						<div class="speaker-company">{{ .Params.company }}</div>


### PR DESCRIPTION
Issue #12 
close #12 
Fixes background image URL syntax in the speaker card on /layouts/sessions/single.html. The update ensures the photoURL is correctly formatted and displayed in the background-image CSS property.