### PR TITLE
Fix background image URL syntax in speaker card

### DIFF
--- a/layouts/partials/session.html
+++ b/layouts/partials/session.html
@@ -32,7 +32,7 @@
 <ul class="speakers">
 	{{ range where .Site.RegularPages "Params.key" "in" .Params.speakers }}
 	<li class="speaker">
-		<div class="speaker-img" style="background-image: url({{ .Params.photoURL }});"></div>
+		<div class="speaker-img" style="background-image: url('{{ .Params.photoURL }}');"></div>
 		<strong class="speaker-name">{{ .Params.name }}</strong>
 		<span class="speaker-country">{{ .Params.country }}</span>
 		<div class="speaker-company">{{ .Params.company }}</div>

--- a/layouts/sessions/single.html
+++ b/layouts/sessions/single.html
@@ -21,7 +21,7 @@
 				<li>
 					<a class="visually-hidden" aria-hidden="true" href="/speakers/{{ .Params.key }}">{{ .Params.name }}</a>
 					<a class="speaker" href="/speakers/{{ .Params.key }}">
-						<div class="speaker-img" style="background-image: url({{ .Params.photoURL }});"></div>
+						<div class="speaker-img" style="background-image: url('{{ .Params.photoURL }}');"></div>
 						<strong class="speaker-name">{{ .Params.name }}</strong>
 						<span class="speaker-country">{{ .Params.city }}</span>
 						<div class="speaker-company">{{ .Params.company }}</div>

--- a/layouts/speakers/single.html
+++ b/layouts/speakers/single.html
@@ -3,7 +3,7 @@
 <div class="hero" style="padding: 30px;">
 
 	<header>
-		<div class="speaker-img" style="background-image: url({{ .Page.Params.photoURL }});"></div>
+		<div class="speaker-img" style="background-image: url('{{ .Page.Params.photoURL }}');"></div>
 		<div>
 			<h1>{{ .Page.Params.name }}</h1>
 


### PR DESCRIPTION
Fixes background image URL syntax in the speaker card on /layouts/sessions/single.html. The update ensures the photoURL is correctly formatted and displayed in the background-image CSS property.

Issue #12 
close #12 
close #8 