### PR TITLE
fix: Speakers image on home page should redirect to their correct link

### DIFF
--- a/layouts/partials/speaker.html
+++ b/layouts/partials/speaker.html
@@ -1,0 +1,9 @@
+<a class="visually-hidden" aria-hidden="true" href="/speakers/{{ .Params.key }}">{{ .Params.name }}</a>
+<a class="speaker" href="/speakers/{{ .Params.key }}">
+	<div role="presentation" class="speaker-img" style="background-image: url('{{ .Params.photoURL }}');"></div>
+	<div class="info">
+		<div class="speaker-company">{{ .Params.company }}</div>
+		<strong class="speaker-name">{{ .Params.name }}</strong>
+		<span class="speaker-country">{{ .Params.city }}</span>
+	</div>
+</a>


### PR DESCRIPTION
This PR addresses bug #10  where the speaker images on the homepage were redirecting to incorrect links. The speaker images now correctly redirect to their respective speaker profile pages.

Issue #10 
close #10 

