### PR TITLE
fix: Syntax Issue Using .Get Method

### DIFF
--- a/layouts/shortcodes/home-location.html
+++ b/layouts/shortcodes/home-location.html
@@ -1,7 +1,11 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
+{{ $image := .Get "image" }}
+{{ $address := .Get "address" }}
+{{ $latitude := .Get "latitude" }}
+{{ $longitude := .Get "longitude" }}
 <section class="location">
 
-	<div class="map" style="background-image: url('{{ .Get "image" }}');"></div>
+	<div class="map" style="background-image: url('{{ $image }}');"></div>
 
 	<div class="description">
 		<div class="inner">
@@ -11,7 +15,7 @@
 		<div class="direction">
 			{{ .Get "address" }}
 
-			<a href="https://www.google.com/maps/dir/?api=1&destination={{ .Get "latitude" }},{{ .Get "longitude" }}"
+			<a href="https://www.google.com/maps/dir/?api=1&destination={{ $latitude }},{{ $longitude }}"
 				class="btn btn-icon-only" target="_blank" rel="noreferrer"
 			   aria-label="{{ i18n "home_location_direction" }}">
 				{{ partial "icon.html" "direction" }}

--- a/layouts/shortcodes/jumbo.html
+++ b/layouts/shortcodes/jumbo.html
@@ -3,7 +3,7 @@
 {{ $imgLabel := .Get "imgLabel" }}
 {{ $logo := .Site.Params.logos.jumbo }}
 <div class="jumbo">
-	<div class="jumbo-cover" style="background-image: url('{{ .Get "img" }}')" {{ if $imgLabel }}aria-label="{{ $imgLabel }}"{{ end }}></div>
+	<div class="jumbo-cover" style="background-image: url('{{ $img }}')" {{ if $imgLabel }}aria-label="{{ $imgLabel }}"{{ end }}></div>
 	<div class="inner-wrapper">
 		{{ if $logo }}
 		<img class="jumbo-logo" src="{{ $logo }}" alt="logo {{ .Site.Title }}">


### PR DESCRIPTION
This PR fixes the incorrect usage of the .Get method in layouts/shortcodes/jumbo.html and layouts/shortcodes/home-location.html for retrieving image URLs and location parameters. The update ensures proper data retrieval, resolving rendering issues.
issue #17 
close #17 